### PR TITLE
Fix compilation on GHC 7.2.1

### DIFF
--- a/src/Test/Framework/TH.hs
+++ b/src/Test/Framework/TH.hs
@@ -20,7 +20,7 @@ import Language.Haskell.TH
 import Language.Haskell.Exts.Parser
 import Language.Haskell.Exts.Syntax
 import Text.Regex.Posix
-import Maybe
+import Data.Maybe
 import Language.Haskell.Exts.Extension
 import Language.Haskell.Extract 
 

--- a/test-framework-th.cabal
+++ b/test-framework-th.cabal
@@ -57,7 +57,7 @@ author: Oscar Finnsson & Emil Nordling
 
 library
   exposed-modules: Test.Framework.TH 
-  build-depends: base >= 4 && < 5, test-framework, language-haskell-extract >= 0.2, haskell-src-exts, haskell98, regex-posix, template-haskell
+  build-depends: base >= 4 && < 5, test-framework, language-haskell-extract >= 0.2, haskell-src-exts, regex-posix, template-haskell
   hs-source-dirs: src
 
 


### PR DESCRIPTION
From GHC 7.2.1 on it is no longer possible to use the `haskell98`
package together with the `base` package. This conflict is resolved by
removing the dependancy on `haskell98`.
