### PR TITLE
defaultMainGenerator2

### DIFF
--- a/src/Test/Framework/TH.hs
+++ b/src/Test/Framework/TH.hs
@@ -14,6 +14,7 @@
 
 module Test.Framework.TH (
   defaultMainGenerator,
+  defaultMainGenerator2,
   testGroupGenerator
 ) where
 import Language.Haskell.TH
@@ -60,6 +61,10 @@ import Test.Framework (defaultMain, testGroup)
 defaultMainGenerator :: ExpQ
 defaultMainGenerator = 
   [| defaultMain [ testGroup $(locationModule) $ $(propListGenerator) ++ $(caseListGenerator) ] |]
+
+defaultMainGenerator2 :: ExpQ
+defaultMainGenerator2 = 
+  [| defaultMain [ testGroup $(locationModule) $ $(caseListGenerator) ++ $(propListGenerator) ] |]
 
 -- | Generate the usual code and extract the usual functions needed for a testGroup in HUnit/Quickcheck/Quickcheck2.
 --   All functions beginning with case_ or prop_ will be extracted.


### PR DESCRIPTION
First of all, thank you for your great package.

defaultMainGenerator2 generates a list which contains props first and cases second. 

I usually write props and try tests. When QuickCheck find a specific data, I create cases. So, cases should be tested first next time to save my time.
