### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/test-framework-th.cabal
+++ b/test-framework-th.cabal
@@ -1,6 +1,6 @@
 name: test-framework-th
 version: 0.2.4
-cabal-version: >= 1.6
+cabal-version: >= 1.8
 build-type: Simple
 license: BSD3
 license-file: BSD3.txt


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: test-framework-th.cabal:60:30: version operators used. To use version                                                                                                                                                                                                     
operators the package needs to specify at least 'cabal-version: >= 1.8'.        
```